### PR TITLE
Fix Spigot dependency in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <!-- Spigot-API -->
     <dependency>
       <groupId>org.spigotmc</groupId>
-      <artifactId>spigot</artifactId>
+      <artifactId>spigot-api</artifactId>
       <version>1.8.7-R0.1-SNAPSHOT</version>
     </dependency>
     <!-- Lombok -->


### PR DESCRIPTION
Maven fails to build Leave because it is unable to pull the Spigot dependency required. The `artifiactId` for the API is incorrect, as I discovered by browsing https://hub.spigotmc.org/nexus/content/groups/public/org/spigotmc/

This PR corrects the `artifactId` to `spigot-api` which fixes the build process. This change was tested by server admin ngtFlyer and the plugin works very well on his server.

P.S. Thank you for this plugin; nice and simple!
